### PR TITLE
Fixes 718 in the 2.0 code by removing appdomain hooks

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -66,25 +66,8 @@ namespace Serilog.Sinks.PeriodicBatching
 #else
             _timer = new PortableTimer(cancel => OnTick());
 #endif
-
-#if APPDOMAIN
-            AppDomain.CurrentDomain.DomainUnload += OnAppDomainUnloading;
-            AppDomain.CurrentDomain.ProcessExit += OnAppDomainUnloading;
-            AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnloading;
-#endif
         }
-
-#if APPDOMAIN
-        void OnAppDomainUnloading(object sender, EventArgs args)
-        {
-            var eventArgs = args as UnhandledExceptionEventArgs;
-            if (eventArgs != null && !eventArgs.IsTerminating)
-                return;
-
-            CloseAndFlush();
-        }
-#endif
-
+        
         void CloseAndFlush()
         {
             lock (_stateLock)
@@ -94,13 +77,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
                 _unloading = true;
             }
-
-#if APPDOMAIN
-            AppDomain.CurrentDomain.DomainUnload -= OnAppDomainUnloading;
-            AppDomain.CurrentDomain.ProcessExit -= OnAppDomainUnloading;
-            AppDomain.CurrentDomain.UnhandledException -= OnAppDomainUnloading;
-#endif
-
+            
 #if WAITABLE_TIMER
             var wh = new ManualResetEvent(false);
             if (_timer.Dispose(wh))

--- a/src/Serilog.Sinks.PeriodicBatching/project.json
+++ b/src/Serilog.Sinks.PeriodicBatching/project.json
@@ -15,7 +15,7 @@
   "frameworks": {
     "net45": {
       "compilationOptions": {
-        "define": [ "APPDOMAIN", "WAITABLE_TIMER" ]
+        "define": [ "WAITABLE_TIMER" ]
       }
     },
     "dotnet5.2": {

--- a/test/Serilog.Tests/project.json
+++ b/test/Serilog.Tests/project.json
@@ -17,7 +17,7 @@
     "dnx452": {
       "compilationOptions": {
         "keyFile": "../../assets/Serilog.snk",
-        "define": [ "APPSETTINGS", "PROCESS", "FILE_IO", "PERIODIC_BATCHING", "INTERNAL_TESTS", "REMOTING", "APPDOMAIN" ]
+        "define": [ "APPSETTINGS", "PROCESS", "FILE_IO", "PERIODIC_BATCHING", "INTERNAL_TESTS", "REMOTING" ]
       },
       "frameworkAssemblies": {
         "System.Configuration": ""


### PR DESCRIPTION
Proposed fix for #718 in the 2.0 codebase: removes broken `AppDomain` shutdown hooks from `PeriodicBatchingSink`.

Because these are not available under .NET Core, they can't be relied on in Serilog 2 anyway, so all code should shut down the logger by calling either `Log.CloseAndFlush()` or disposing the logging pipeline manually.

Another 2.0 PR coming which will (finally) make the return type of `LoggerConfiguration.CreateLogger()` disposable so that the contract is more clearly visible.

Ping @merbla @khellang thoughts?
