### PR TITLE
Align PortableTimer's behavior with System.Threading.Timer

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
@@ -69,9 +69,7 @@ namespace Serilog.Sinks.PeriodicBatching
                     {
                         try
                         {
-                            lock (_stateLock)
-                                if (_state != PortableTimerState.Disposed)
-                                    _state = PortableTimerState.Active;
+                            _state = PortableTimerState.Active;
 
                             if (!_cancel.Token.IsCancellationRequested)
                             {
@@ -85,8 +83,7 @@ namespace Serilog.Sinks.PeriodicBatching
                         finally
                         {
                             lock (_stateLock)
-                                if (_state != PortableTimerState.Disposed)
-                                    _state = PortableTimerState.NotWaiting;
+                                _state = PortableTimerState.NotWaiting;
                         }
                     },
                     CancellationToken.None,

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
@@ -69,7 +69,9 @@ namespace Serilog.Sinks.PeriodicBatching
                     {
                         try
                         {
-                            _state = PortableTimerState.Active;
+                            lock (_stateLock)
+                                if (_state != PortableTimerState.Disposed)
+                                    _state = PortableTimerState.Active;
 
                             if (!_cancel.Token.IsCancellationRequested)
                             {
@@ -83,7 +85,8 @@ namespace Serilog.Sinks.PeriodicBatching
                         finally
                         {
                             lock (_stateLock)
-                                _state = PortableTimerState.NotWaiting;
+                                if (_state != PortableTimerState.Disposed)
+                                    _state = PortableTimerState.NotWaiting;
                         }
                     },
                     CancellationToken.None,

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/PortableTimerTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/PortableTimerTests.cs
@@ -1,0 +1,59 @@
+﻿#if NETCOREAPP1_0
+
+using Serilog.Debugging;
+using Serilog.Sinks.PeriodicBatching;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace Serilog.Tests.Sinks.PeriodicBatching
+{
+    public class PortableTimerTests
+    {
+        [Fact]
+        public void WhenItStartsItWaitsUntilHandled_OnDispose()
+        {
+            bool wasCalled = false;
+            using (var timer = new PortableTimer(delegate { Thread.Sleep(50); wasCalled = true; }))
+            { 
+                timer.Start(TimeSpan.Zero);
+                Thread.Sleep(10);
+            }
+
+            Assert.True(wasCalled);
+        }
+
+        [Fact]
+        public void WhenWaitingShouldCancel_OnDispose()
+        {
+            bool wasCalled = false;
+            bool writtenToSelflog = false;
+
+            SelfLog.Enable(_ => writtenToSelflog = true);
+
+            using (var timer = new PortableTimer(delegate { Thread.Sleep(50); wasCalled = true; }))
+            {
+                timer.Start(TimeSpan.FromMilliseconds(10));
+            }
+
+            Thread.Sleep(100);
+
+            Assert.False(wasCalled, "tick handler was called");
+            Assert.False(writtenToSelflog, "message was written to SelfLog");
+        }
+
+        [Fact]
+        public void WhenDisposedWillThrow_OnStart()
+        {
+            bool wasCalled = false;
+            var timer = new PortableTimer(delegate { wasCalled = true; });
+            timer.Start(TimeSpan.FromMilliseconds(100));
+            timer.Dispose();
+
+            Assert.False(wasCalled);
+            Assert.Throws<ObjectDisposedException>(() => timer.Start(TimeSpan.Zero));
+        }
+    }
+}
+
+#endif

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/PortableTimerTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/PortableTimerTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP1_0
+﻿#if !WAITABLE_TIMER
 
 using Serilog.Debugging;
 using Serilog.Sinks.PeriodicBatching;

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/project.json
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/project.json
@@ -11,11 +11,6 @@
     "keyFile": "../../assets/Serilog.snk"
   },
   "frameworks": {
-    "net4.5.2": {
-      "buildOptions": {
-        "define": [ "WAITABLE_TIMER" ]
-      }
-    },
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
@@ -27,6 +22,12 @@
         "dnxcore50",
         "portable-net45+win8"
       ]
+    },
+
+    "net4.5.2": {
+      "buildOptions": {
+        "define": [ "WAITABLE_TIMER" ]
+      }
     }
   }
 }


### PR DESCRIPTION
fixes [#7](https://github.com/serilog/serilog-sinks-periodicbatching/issues/7)
also should cover [#4](https://github.com/serilog/serilog-sinks-periodicbatching/issues/4)
