### PR TITLE
Making use of System.Threading.Timer on netstandard1.2+

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !WAITABLE_TIMER
-
 using Serilog.Debugging;
 using System;
 using System.Threading;
@@ -148,4 +146,3 @@ namespace Serilog.Sinks.PeriodicBatching
         } 
     }
 }
-#endif

--- a/src/Serilog.Sinks.PeriodicBatching/project.json
+++ b/src/Serilog.Sinks.PeriodicBatching/project.json
@@ -18,7 +18,7 @@
   "frameworks": {
     "net4.5": {
       "buildOptions": {
-        "define": [ "WAITABLE_TIMER", "THREAD" ]
+        "define": [ "WAITABLE_TIMER" ]
       }
     },
     "netstandard1.1": {
@@ -28,11 +28,10 @@
     },
     "netstandard1.3": {
       "buildOptions": {
-        "define": [ "THREAD" ]
+        "define": [  ]
       },
       "dependencies": {
         "System.Collections.Concurrent": "4.0.12",
-        "System.Threading.Thread": "4.0.0"
       }
     }
   }

--- a/src/Serilog.Sinks.PeriodicBatching/project.json
+++ b/src/Serilog.Sinks.PeriodicBatching/project.json
@@ -18,7 +18,7 @@
   "frameworks": {
     "net4.5": {
       "buildOptions": {
-        "define": [ "WAITABLE_TIMER" ]
+        "define": [ "THREADING_TIMER" ]
       }
     },
     "netstandard1.1": {
@@ -26,12 +26,13 @@
         "System.Collections.Concurrent": "4.0.12"
       }
     },
-    "netstandard1.3": {
+    "netstandard1.2": {
       "buildOptions": {
-        "define": [  ]
+        "define": [ "THREADING_TIMER" ]
       },
       "dependencies": {
         "System.Collections.Concurrent": "4.0.12",
+        "System.Threading.Timer": "4.0.1"
       }
     }
   }

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/PortableTimerTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/PortableTimerTests.cs
@@ -1,9 +1,8 @@
-﻿#if !WAITABLE_TIMER
-
-using Serilog.Debugging;
+﻿using Serilog.Debugging;
 using Serilog.Sinks.PeriodicBatching;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Serilog.Tests.Sinks.PeriodicBatching
@@ -33,13 +32,35 @@ namespace Serilog.Tests.Sinks.PeriodicBatching
 
             using (var timer = new PortableTimer(delegate { Thread.Sleep(50); wasCalled = true; }))
             {
-                timer.Start(TimeSpan.FromMilliseconds(10));
+                timer.Start(TimeSpan.FromMilliseconds(20));
             }
 
             Thread.Sleep(100);
 
             Assert.False(wasCalled, "tick handler was called");
             Assert.False(writtenToSelflog, "message was written to SelfLog");
+        }
+
+        [Fact]
+        public void WhenActiveShouldCancel_OnDispose()
+        {
+            bool wasCalled = false;
+            bool writtenToSelflog = false;
+
+            SelfLog.Enable(_ => writtenToSelflog = true);
+
+            using (var timer = new PortableTimer(
+                                    token => {
+                                        wasCalled = true;
+                                        Task.Delay(TimeSpan.FromMilliseconds(50), token).GetAwaiter().GetResult();
+                                    }))
+            {
+                timer.Start(TimeSpan.FromMilliseconds(20));
+                Thread.Sleep(40);
+            }
+
+            Assert.True(wasCalled, "tick handler wasn't called");
+            Assert.True(writtenToSelflog, "message wasn't written to SelfLog");
         }
 
         [Fact]
@@ -53,7 +74,51 @@ namespace Serilog.Tests.Sinks.PeriodicBatching
             Assert.False(wasCalled);
             Assert.Throws<ObjectDisposedException>(() => timer.Start(TimeSpan.Zero));
         }
+
+        [Fact]
+        public void WhenOverlapsShouldProcessOneAtTime_OnTick()
+        {
+            bool userHandlerOverlapped = false;
+
+            PortableTimer timer = null;
+            timer = new PortableTimer(
+                _ =>
+                {
+                    if (Monitor.TryEnter(timer))
+                    {
+                        try
+                        {
+                            timer.Start(TimeSpan.FromMilliseconds(0));
+                            Thread.Sleep(1);
+                        }
+                        finally
+                        {
+                            Monitor.Exit(timer);
+                        }
+                    }
+                    else
+                    {
+                        userHandlerOverlapped = true;
+                    }                    
+                });
+
+            timer.Start(TimeSpan.FromMilliseconds(1));
+            Thread.Sleep(50);
+            timer.Dispose();
+
+            Assert.False(userHandlerOverlapped);
+        }
+
+        [Fact]
+        public void CanBeDisposedFromMultipleThreads()
+        {
+            PortableTimer timer = null;
+            timer = new PortableTimer(_ => timer.Start(TimeSpan.FromMilliseconds(1)));
+
+            timer.Start(TimeSpan.Zero);
+            Thread.Sleep(50);
+
+            Parallel.For(0, Environment.ProcessorCount * 2, _ => timer.Dispose());
+        }        
     }
 }
-
-#endif

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/project.json
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/project.json
@@ -25,9 +25,6 @@
     },
 
     "net4.5.2": {
-      "buildOptions": {
-        "define": [ "WAITABLE_TIMER" ]
-      }
     }
   }
 }


### PR DESCRIPTION
Consider this change to `PortableTimer` that implements option (3) from [this ](https://github.com/serilog/serilog-sinks-periodicbatching/issues/7#issuecomment-244632130)discussion, using `System.Threading.Timer` for both `.Net Core` and `.Net Framework`. Besides it also removes dependency on `Dispose(WaitHandle)` that prevents use of async handlers that were abandoned in [this old commit](https://github.com/serilog/serilog/commit/4bfc5f5c).

If all is ok it should be small changes to the sink itself that bring back "more async". Most of the network sinks support async I/O so they should benefit from a bit less pressure on the `ThreadPool`. 
