### PR TITLE
Bounding requirement for PeriodicBatchingSink 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,5 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+BenchmarkDotNet.Artifacts/

--- a/RunPerfTests.ps1
+++ b/RunPerfTests.ps1
@@ -1,0 +1,16 @@
+Push-Location $PSScriptRoot
+
+./Build.ps1
+
+foreach ($test in ls test/*.PerformanceTests) {
+    Push-Location $test
+
+	echo "perf: Running performance test project in $test"
+
+    & dotnet test -c Release
+    if($LASTEXITCODE -ne 0) { exit 2 }
+
+    Pop-Location
+}
+
+Pop-Location

--- a/serilog-sinks-periodicbatching.sln
+++ b/serilog-sinks-periodicbatching.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{037440DE-440B-4129-9F7A-09B42D00397E}"
 EndProject
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{F6E07A13-B
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Serilog.Sinks.PeriodicBatching.Tests", "test\Serilog.Sinks.PeriodicBatching.Tests\Serilog.Sinks.PeriodicBatching.Tests.xproj", "{3C2D8E01-5580-426A-BDD9-EC59CD98E618}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Serilog.Sinks.PeriodicBatching.PerformanceTests", "test\Serilog.Sinks.PeriodicBatching.PerformanceTests\Serilog.Sinks.PeriodicBatching.PerformanceTests.xproj", "{80B760D1-3862-49AD-9D72-23608550C318}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80B760D1-3862-49AD-9D72-23608550C318}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80B760D1-3862-49AD-9D72-23608550C318}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B760D1-3862-49AD-9D72-23608550C318}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80B760D1-3862-49AD-9D72-23608550C318}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -42,5 +48,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{324C2F52-D9F7-4844-9BC4-9906E228D380} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618} = {F6E07A13-B9D3-4019-B25A-DE1F6C17E108}
+		{80B760D1-3862-49AD-9D72-23608550C318} = {F6E07A13-B9D3-4019-B25A-DE1F6C17E108}
 	EndGlobalSection
 EndGlobal

--- a/src/Serilog.Sinks.PeriodicBatching/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Properties/AssemblyInfo.cs
@@ -12,3 +12,10 @@ using System.Runtime.CompilerServices;
                               "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
                               "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
                               "b19485ec")]
+
+[assembly: InternalsVisibleTo("Serilog.Sinks.PeriodicBatching.PerformanceTests, PublicKey=" +
+                              "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
+                              "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
+                              "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
+                              "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
+                              "b19485ec")]

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -6,12 +6,17 @@ namespace Serilog.Sinks.PeriodicBatching
 {
     class BoundedConcurrentQueue<T> 
     {
+        const int NON_BOUNDED = -1;
+
         readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         readonly int _queueLimit;
 
         int _counter;
 
-        public BoundedConcurrentQueue(): this(int.MaxValue) { }
+        public BoundedConcurrentQueue() 
+        {
+            _queueLimit = NON_BOUNDED;
+        }
 
         public BoundedConcurrentQueue(int queueLimit)
         {
@@ -25,7 +30,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
         public bool TryDequeue(out T item)
         {
-            if (_queueLimit == int.MaxValue)
+            if (_queueLimit == NON_BOUNDED)
                 return _queue.TryDequeue(out item);
 
             var result = false;
@@ -45,7 +50,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
         public bool TryEnqueue(T item)
         {
-            if (_queueLimit == int.MaxValue)
+            if (_queueLimit == NON_BOUNDED)
             {
                 _queue.Enqueue(item);
                 return true;

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Serilog.Sinks.PeriodicBatching
+{
+    class BoundedConcurrentQueue<T> 
+    {
+        readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
+        readonly int _queueLimit;
+
+        int _counter;
+
+        public BoundedConcurrentQueue(): this(int.MaxValue) { }
+
+        public BoundedConcurrentQueue(int queueLimit)
+        {
+            if (queueLimit <= 0)
+                throw new ArgumentOutOfRangeException(nameof(queueLimit), "queue limit must be positive");
+
+            _queueLimit = queueLimit;
+        }
+
+        public int Count => _queue.Count;
+
+        public bool TryDequeue(out T item)
+        {
+            if (_queueLimit == int.MaxValue)
+                return _queue.TryDequeue(out item);
+
+            var result = false;
+            try
+            { }
+            finally // prevent state corrupt while aborting
+            {
+                if (_queue.TryDequeue(out item))
+                {
+                    Interlocked.Decrement(ref _counter);
+                    result = true;
+                }
+            }
+
+            return result;
+        }
+
+        public bool TryEnqueue(T item)
+        {
+            if (_queueLimit == int.MaxValue)
+            {
+                _queue.Enqueue(item);
+                return true;
+            }
+
+            var result = true;
+            try
+            { }
+            finally
+            {
+                if (Interlocked.Increment(ref _counter) <= _queueLimit)
+                {
+                    _queue.Enqueue(item);
+                }
+                else
+                {
+                    Interlocked.Decrement(ref _counter);
+                    result = false;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/BoundedQueue_Enqueue_Benchmark.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/BoundedQueue_Enqueue_Benchmark.cs
@@ -1,0 +1,67 @@
+﻿using BenchmarkDotNet.Attributes;
+using Serilog.Events;
+using Serilog.Sinks.PeriodicBatching.PerformanceTests.Support;
+using Serilog.Tests.Support;
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.PeriodicBatching.PerformanceTests
+{
+    public class BoundedQueue_Enqueue_Benchmark
+    {
+        [Params(100, 1000)]
+        public int ItemsCount { get; set; }
+
+        [Params(100, 1000)]
+        public int QueueLimit { get; set; }
+
+        [Params(1, -1)]
+        public int MaxDegreeOfParallelism { get; set; }
+
+        readonly LogEvent _logEvent = Some.LogEvent();
+
+        ConcurrentQueue<LogEvent> _concurrentQueue;
+        BlockingCollection<LogEvent> _blockingCollection;
+        BoundedConcurrentQueue<LogEvent> _boundedConcurrentQueue;
+        SynchronizedQueue<LogEvent> _syncronizedQueue;
+
+        [Setup]
+        public void Setup()
+        {
+            _concurrentQueue = new ConcurrentQueue<LogEvent>();
+            _blockingCollection = new BlockingCollection<LogEvent>(QueueLimit);
+            _boundedConcurrentQueue = new BoundedConcurrentQueue<LogEvent>(QueueLimit);
+            _syncronizedQueue = new SynchronizedQueue<LogEvent>(QueueLimit);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ConcurrentQueue()
+        {
+            EnqueueItems(evt => _concurrentQueue.Enqueue(evt));
+        }
+
+        [Benchmark]
+        public void BoundedConcurrentQueue()
+        {
+            EnqueueItems(evt => _boundedConcurrentQueue.TryEnqueue(evt));
+        }
+
+        [Benchmark]
+        public void BlockingCollection()
+        {
+            EnqueueItems(evt => _blockingCollection.TryAdd(evt));
+        }
+
+        [Benchmark]
+        public void SynchronizedQueue()
+        {
+            EnqueueItems(evt => _syncronizedQueue.TryEnqueue(evt));
+        }
+
+        void EnqueueItems(Action<LogEvent> enqueueAction)
+        {
+            Parallel.For(0, ItemsCount, new ParallelOptions() { MaxDegreeOfParallelism = MaxDegreeOfParallelism }, _ => enqueueAction(_logEvent));
+        }
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/BoundedQueue_Enqueue_Dequeue_Benchmark.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/BoundedQueue_Enqueue_Dequeue_Benchmark.cs
@@ -1,0 +1,66 @@
+﻿using BenchmarkDotNet.Attributes;
+using Serilog.Events;
+using Serilog.Sinks.PeriodicBatching.PerformanceTests.Support;
+using Serilog.Tests.Support;
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.PeriodicBatching.PerformanceTests
+{
+    public class BoundedQueue_Enqueue_Dequeue_Benchmark
+    {
+        [Params(100, 1000)]
+        public int ItemsCount { get; set; }
+
+        [Params(100, 1000)]
+        public int QueueLimit { get; set; }
+
+        readonly LogEvent _logEvent = Some.LogEvent();
+
+        ConcurrentQueue<LogEvent> _concurrentQueue;
+        BlockingCollection<LogEvent> _blockingCollection;
+        BoundedConcurrentQueue<LogEvent> _boundedConcurrentQueue;
+        SynchronizedQueue<LogEvent> _syncronizedQueue;
+
+        [Setup]
+        public void Setup()
+        {
+            _concurrentQueue = new ConcurrentQueue<LogEvent>();
+            _blockingCollection = new BlockingCollection<LogEvent>(QueueLimit);
+            _boundedConcurrentQueue = new BoundedConcurrentQueue<LogEvent>(QueueLimit);
+            _syncronizedQueue = new SynchronizedQueue<LogEvent>(QueueLimit);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ConcurrentQueue()
+        {
+            EnqueueDequeueItems(evt => _concurrentQueue.Enqueue(evt), evt => _concurrentQueue.TryDequeue(out evt));
+        }
+
+        [Benchmark]
+        public void BoundedConcurrentQueue()
+        {
+            EnqueueDequeueItems(evt => _boundedConcurrentQueue.TryEnqueue(evt), evt => _boundedConcurrentQueue.TryDequeue(out evt));
+        }
+
+        [Benchmark]
+        public void BlockingCollection()
+        {
+            EnqueueDequeueItems(evt => _blockingCollection.TryAdd(evt), evt => _blockingCollection.TryTake(out evt));
+        }
+
+        [Benchmark]
+        public void SynchronizedQueue()
+        {
+            EnqueueDequeueItems(evt => _syncronizedQueue.TryEnqueue(evt), evt => _syncronizedQueue.TryDequeue(out evt));
+        }
+
+        void EnqueueDequeueItems(Action<LogEvent> enqueueAction, Action<LogEvent> dequeueAction)
+        {
+            Parallel.Invoke(
+                () => Parallel.For(0, ItemsCount, _ => enqueueAction(_logEvent)),
+                () => { for (var i = 0; i < ItemsCount; i++) dequeueAction(_logEvent); });
+        }
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Properties/AssemblyInfo.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Serilog.Sinks.PeriodicBatching.PerformanceTests")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("80b760d1-3862-49ad-9d72-23608550c318")]

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Runner.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Runner.cs
@@ -1,0 +1,20 @@
+﻿using BenchmarkDotNet.Running;
+using Xunit;
+
+namespace Serilog.Sinks.PeriodicBatching.PerformanceTests
+{
+    public class Runner
+    {
+        [Fact]
+        public void BoundedQueue_Enqueue()
+        {
+            BenchmarkRunner.Run<BoundedQueue_Enqueue_Benchmark>();
+        }
+
+        [Fact]
+        public void BoundedQueue_Enqueue_Dequeue()
+        {
+            BenchmarkRunner.Run<BoundedQueue_Enqueue_Dequeue_Benchmark>();
+        }
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Serilog.Sinks.PeriodicBatching.PerformanceTests.xproj
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Serilog.Sinks.PeriodicBatching.PerformanceTests.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>80b760d1-3862-49ad-9d72-23608550c318</ProjectGuid>
+    <RootNamespace>Serilog.Sinks.PeriodicBatching.PerformanceTests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Support/Some.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Support/Some.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Serilog.Tests.Support
+{
+    static class Some
+    {
+        static int Counter;
+
+        public static int Int()
+        {
+            return Interlocked.Increment(ref Counter);
+        }
+
+        public static decimal Decimal()
+        {
+            return Int() + 0.123m;
+        }
+
+        public static string String(string tag = null)
+        {
+            return (tag ?? "") + "__" + Int();
+        }
+
+        public static TimeSpan TimeSpan()
+        {
+            return System.TimeSpan.FromMinutes(Int());
+        }
+
+        public static DateTime Instant()
+        {
+            return new DateTime(2012, 10, 28) + TimeSpan();
+        }
+
+        public static DateTimeOffset OffsetInstant()
+        {
+            return new DateTimeOffset(Instant());
+        }
+
+        public static LogEvent LogEvent(DateTimeOffset? timestamp = null, LogEventLevel level = LogEventLevel.Information)
+        {
+            return new LogEvent(timestamp ?? OffsetInstant(), level,
+                null, MessageTemplate(), Enumerable.Empty<LogEventProperty>());
+        }
+
+        public static LogEvent InformationEvent(DateTimeOffset? timestamp = null)
+        {
+            return LogEvent(timestamp, LogEventLevel.Information);
+        }
+
+        public static LogEvent DebugEvent(DateTimeOffset? timestamp = null)
+        {
+            return LogEvent(timestamp, LogEventLevel.Debug);
+        }
+
+        public static LogEventProperty LogEventProperty()
+        {
+            return new LogEventProperty(String(), new ScalarValue(Int()));
+        }
+
+        public static string NonexistentTempFilePath()
+        {
+            return Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+        }
+
+        public static string TempFilePath()
+        {
+            return Path.GetTempFileName();
+        }
+
+        public static string TempFolderPath()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        public static MessageTemplate MessageTemplate()
+        {
+            return new MessageTemplateParser().Parse(String());
+        }
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Support/SynchronizedQueue.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Support/SynchronizedQueue.cs
@@ -4,7 +4,14 @@ namespace Serilog.Sinks.PeriodicBatching.PerformanceTests.Support
 {
     class SynchronizedQueue<T> : Queue<T>
     {
+        const int NON_BOUNDED = -1;
+
         readonly int _queueLimit;
+
+        public SynchronizedQueue()
+        {
+            _queueLimit = NON_BOUNDED;
+        }
 
         public SynchronizedQueue(int queueLimit)
         {
@@ -31,7 +38,7 @@ namespace Serilog.Sinks.PeriodicBatching.PerformanceTests.Support
         {
             lock (this)
             {
-                if (base.Count < _queueLimit)
+                if (base.Count < _queueLimit || _queueLimit == NON_BOUNDED)
                 {
                     base.Enqueue(item);
                     return true;

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Support/SynchronizedQueue.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Support/SynchronizedQueue.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace Serilog.Sinks.PeriodicBatching.PerformanceTests.Support
+{
+    class SynchronizedQueue<T> : Queue<T>
+    {
+        readonly int _queueLimit;
+
+        public SynchronizedQueue(int queueLimit)
+        {
+            _queueLimit = queueLimit;
+        }
+
+        public bool TryDequeue(out T item)
+        {
+            item = default(T);
+
+            lock (this)
+            {
+                if (base.Count > 0)
+                {
+                    item = base.Dequeue();
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public bool TryEnqueue(T item)
+        {
+            lock (this)
+            {
+                if (base.Count < _queueLimit)
+                {
+                    base.Enqueue(item);
+                    return true;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/project.json
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/project.json
@@ -1,0 +1,31 @@
+﻿{
+  "version": "2.0.0",
+  "testRunner": "xunit",
+  "dependencies": {
+    "Serilog": "2.0.0",
+    "Serilog.Sinks.PeriodicBatching": { "target": "project" },
+    "xunit": "2.2.0-*",
+    "dotnet-test-xunit": "2.2.0-*",
+    "BenchmarkDotNet": "0.9.9"
+  },
+  "buildOptions": {
+    "keyFile": "../../assets/Serilog.snk"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    },
+
+    "net452": {
+    }
+  }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/net452/BoundedQueue_Enqueue_Benchmark-report-github.md
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/net452/BoundedQueue_Enqueue_Benchmark-report-github.md
@@ -1,0 +1,64 @@
+```ini
+
+Host Process Environment Information:
+BenchmarkDotNet.Core=v0.9.9.0
+OS=Microsoft Windows NT 6.2.9200.0
+Processor=Intel(R) Core(TM) i7-4790 CPU 3.60GHz, ProcessorCount=8
+Frequency=3507522 ticks, Resolution=285.1016 ns, Timer=TSC
+CLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
+GC=Concurrent Workstation
+JitModules=clrjit-v4.6.1586.0
+
+Type=BoundedQueue_Enqueue_Benchmark  Mode=Throughput  
+
+```
+                 Method | Items | Limit | ConcurrencyLevel |        Median |     StdDev | Scaled | Scaled-SD |
+----------------------- |------ |------ |----------------- |-------------- |----------- |------- |---------- |
+        **ConcurrentQueue** |    **50** |    **-1** |               **-1** |     **4.5754 us** |  **0.0268 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    -1 |               -1 |     4.9072 us |  0.0208 us |   1.07 |      0.01 |
+     BlockingCollection |    50 |    -1 |               -1 |    15.2352 us |  0.4025 us |   3.33 |      0.09 |
+      SynchronizedQueue |    50 |    -1 |               -1 |     7.0956 us |  0.0633 us |   1.55 |      0.02 |
+        **ConcurrentQueue** |    **50** |    **-1** |                **1** |     **2.5920 us** |  **0.0757 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    -1 |                1 |     2.7877 us |  0.0632 us |   1.07 |      0.04 |
+     BlockingCollection |    50 |    -1 |                1 |     5.4940 us |  0.1542 us |   2.13 |      0.08 |
+      SynchronizedQueue |    50 |    -1 |                1 |     3.1676 us |  0.0917 us |   1.23 |      0.05 |
+        **ConcurrentQueue** |    **50** |    **50** |               **-1** |     **4.5830 us** |  **0.0276 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    50 |               -1 |     5.6700 us |  0.0270 us |   1.24 |      0.01 |
+     BlockingCollection |    50 |    50 |               -1 |    23.7805 us |  2.4256 us |   5.36 |      0.52 |
+      SynchronizedQueue |    50 |    50 |               -1 |     6.9731 us |  0.0735 us |   1.53 |      0.02 |
+        **ConcurrentQueue** |    **50** |    **50** |                **1** |     **2.6240 us** |  **0.0599 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    50 |                1 |     3.0955 us |  0.0685 us |   1.19 |      0.04 |
+     BlockingCollection |    50 |    50 |                1 |     8.1912 us |  0.5452 us |   3.12 |      0.22 |
+      SynchronizedQueue |    50 |    50 |                1 |     3.1104 us |  0.1233 us |   1.20 |      0.05 |
+        **ConcurrentQueue** |    **50** |   **100** |               **-1** |     **4.6141 us** |  **0.0494 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |   100 |               -1 |     5.6492 us |  0.1037 us |   1.23 |      0.03 |
+     BlockingCollection |    50 |   100 |               -1 |    24.1106 us |  1.8002 us |   5.29 |      0.39 |
+      SynchronizedQueue |    50 |   100 |               -1 |     7.0290 us |  0.0761 us |   1.53 |      0.02 |
+        **ConcurrentQueue** |    **50** |   **100** |                **1** |     **2.6345 us** |  **0.0863 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |   100 |                1 |     3.0886 us |  0.0814 us |   1.18 |      0.05 |
+     BlockingCollection |    50 |   100 |                1 |     8.1912 us |  0.5398 us |   3.12 |      0.23 |
+      SynchronizedQueue |    50 |   100 |                1 |     3.1038 us |  0.0882 us |   1.19 |      0.05 |
+        **ConcurrentQueue** |   **100** |    **-1** |               **-1** |     **6.8298 us** |  **0.0668 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    -1 |               -1 |     7.2814 us |  0.0375 us |   1.06 |      0.01 |
+     BlockingCollection |   100 |    -1 |               -1 |    36.2428 us |  5.7991 us |   5.54 |      0.84 |
+      SynchronizedQueue |   100 |    -1 |               -1 |    14.5968 us |  0.3317 us |   2.15 |      0.05 |
+        **ConcurrentQueue** |   **100** |    **-1** |                **1** |     **3.7145 us** |  **0.1000 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    -1 |                1 |     4.0368 us |  0.0925 us |   1.09 |      0.04 |
+     BlockingCollection |   100 |    -1 |                1 |     8.7960 us |  0.5201 us |   2.40 |      0.15 |
+      SynchronizedQueue |   100 |    -1 |                1 |     4.7581 us |  0.1434 us |   1.29 |      0.05 |
+        **ConcurrentQueue** |   **100** |    **50** |               **-1** |     **6.8500 us** |  **0.0586 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    50 |               -1 |     7.9982 us |  0.0915 us |   1.16 |      0.02 |
+     BlockingCollection |   100 |    50 |               -1 |   382.8411 us |  3.2581 us |  55.94 |      0.66 |
+      SynchronizedQueue |   100 |    50 |               -1 |    11.9375 us |  0.1305 us |   1.74 |      0.02 |
+        **ConcurrentQueue** |   **100** |    **50** |                **1** |     **3.7684 us** |  **0.1039 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    50 |                1 |     4.0127 us |  0.0859 us |   1.07 |      0.04 |
+     BlockingCollection |   100 |    50 |                1 | 1,511.4670 us | 17.2323 us | 402.71 |     11.61 |
+      SynchronizedQueue |   100 |    50 |                1 |     4.3747 us |  0.1618 us |   1.15 |      0.05 |
+        **ConcurrentQueue** |   **100** |   **100** |               **-1** |     **6.8885 us** |  **0.0845 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |   100 |               -1 |     8.7115 us |  0.0501 us |   1.26 |      0.02 |
+     BlockingCollection |   100 |   100 |               -1 |    51.7677 us |  5.4497 us |   7.71 |      0.79 |
+      SynchronizedQueue |   100 |   100 |               -1 |    14.4318 us |  0.4317 us |   2.09 |      0.07 |
+        **ConcurrentQueue** |   **100** |   **100** |                **1** |     **3.7928 us** |  **0.0980 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |   100 |                1 |     4.7090 us |  0.0941 us |   1.24 |      0.04 |
+     BlockingCollection |   100 |   100 |                1 |    12.9744 us |  0.0729 us |   3.43 |      0.09 |
+      SynchronizedQueue |   100 |   100 |                1 |     4.6922 us |  0.1199 us |   1.24 |      0.04 |

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/net452/BoundedQueue_Enqueue_Dequeue_Benchmark-report-github.md
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/net452/BoundedQueue_Enqueue_Dequeue_Benchmark-report-github.md
@@ -1,0 +1,40 @@
+```ini
+
+Host Process Environment Information:
+BenchmarkDotNet.Core=v0.9.9.0
+OS=Microsoft Windows NT 6.2.9200.0
+Processor=Intel(R) Core(TM) i7-4790 CPU 3.60GHz, ProcessorCount=8
+Frequency=3507522 ticks, Resolution=285.1016 ns, Timer=TSC
+CLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
+GC=Concurrent Workstation
+JitModules=clrjit-v4.6.1586.0
+
+Type=BoundedQueue_Enqueue_Dequeue_Benchmark  Mode=Throughput  
+
+```
+                 Method | Items | Limit |      Median |     StdDev | Scaled | Scaled-SD |
+----------------------- |------ |------ |------------ |----------- |------- |---------- |
+        **ConcurrentQueue** |    **50** |    **-1** |   **6.7418 us** |  **0.0746 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    -1 |   7.1363 us |  0.0520 us |   1.05 |      0.01 |
+     BlockingCollection |    50 |    -1 |  37.4587 us |  1.5276 us |   5.53 |      0.23 |
+      SynchronizedQueue |    50 |    -1 |  14.1155 us |  0.4030 us |   2.10 |      0.06 |
+        **ConcurrentQueue** |    **50** |    **50** |   **6.6811 us** |  **0.0531 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    50 |   8.3724 us |  0.0714 us |   1.25 |      0.01 |
+     BlockingCollection |    50 |    50 |  52.3829 us |  7.3325 us |   8.07 |      1.08 |
+      SynchronizedQueue |    50 |    50 |  13.7312 us |  0.6096 us |   2.08 |      0.09 |
+        **ConcurrentQueue** |    **50** |   **100** |   **6.7392 us** |  **0.0449 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |   100 |   8.4151 us |  0.1020 us |   1.25 |      0.02 |
+     BlockingCollection |    50 |   100 |  53.9248 us | 13.1645 us |   8.61 |      1.94 |
+      SynchronizedQueue |    50 |   100 |  13.7264 us |  0.3052 us |   2.05 |      0.05 |
+        **ConcurrentQueue** |   **100** |    **-1** |   **9.8471 us** |  **0.2358 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    -1 |  10.1752 us |  0.1060 us |   1.03 |      0.03 |
+     BlockingCollection |   100 |    -1 |  59.9669 us |  2.6132 us |   6.13 |      0.29 |
+      SynchronizedQueue |   100 |    -1 |  29.4077 us |  2.2109 us |   3.01 |      0.23 |
+        **ConcurrentQueue** |   **100** |    **50** |   **9.7427 us** |  **0.1430 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    50 |  12.3263 us |  0.1486 us |   1.26 |      0.02 |
+     BlockingCollection |   100 |    50 | 176.2485 us |  6.4545 us |  18.22 |      0.69 |
+      SynchronizedQueue |   100 |    50 |  26.1062 us |  2.8776 us |   2.77 |      0.29 |
+        **ConcurrentQueue** |   **100** |   **100** |   **9.7086 us** |  **0.0943 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |   100 |  12.3967 us |  0.1212 us |   1.28 |      0.02 |
+     BlockingCollection |   100 |   100 |  71.4098 us |  8.7627 us |   7.65 |      0.88 |
+      SynchronizedQueue |   100 |   100 |  28.9372 us |  1.5055 us |   2.99 |      0.16 |

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/netcoreapp1.0/BoundedQueue_Enqueue_Benchmark-report-github.md
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/netcoreapp1.0/BoundedQueue_Enqueue_Benchmark-report-github.md
@@ -1,0 +1,64 @@
+```ini
+
+Host Process Environment Information:
+BenchmarkDotNet.Core=v0.9.9.0
+OS=Windows
+Processor=?, ProcessorCount=8
+Frequency=3507522 ticks, Resolution=285.1016 ns, Timer=TSC
+CLR=CORE, Arch=64-bit ? [RyuJIT]
+GC=Concurrent Workstation
+dotnet cli version: 1.0.0-preview2-003131
+
+Type=BoundedQueue_Enqueue_Benchmark  Mode=Throughput  
+
+```
+                 Method | Items | Limit | ConcurrencyLevel |        Median |    StdDev | Scaled | Scaled-SD |
+----------------------- |------ |------ |----------------- |-------------- |---------- |------- |---------- |
+        **ConcurrentQueue** |    **50** |    **-1** |               **-1** |     **4.7730 us** | **0.0834 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    -1 |               -1 |     5.1570 us | 0.0419 us |   1.08 |      0.02 |
+     BlockingCollection |    50 |    -1 |               -1 |    15.2293 us | 0.8234 us |   3.25 |      0.18 |
+      SynchronizedQueue |    50 |    -1 |               -1 |     7.6734 us | 0.1142 us |   1.60 |      0.04 |
+        **ConcurrentQueue** |    **50** |    **-1** |                **1** |     **1.6705 us** | **0.0147 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    -1 |                1 |     1.9790 us | 0.0764 us |   1.18 |      0.05 |
+     BlockingCollection |    50 |    -1 |                1 |     4.1712 us | 0.0623 us |   2.49 |      0.04 |
+      SynchronizedQueue |    50 |    -1 |                1 |     2.2616 us | 0.0833 us |   1.35 |      0.05 |
+        **ConcurrentQueue** |    **50** |    **50** |               **-1** |     **4.7571 us** | **0.0811 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    50 |               -1 |     5.6806 us | 0.0393 us |   1.20 |      0.02 |
+     BlockingCollection |    50 |    50 |               -1 |    22.4318 us | 1.3097 us |   4.78 |      0.28 |
+      SynchronizedQueue |    50 |    50 |               -1 |     7.4808 us | 0.0458 us |   1.57 |      0.03 |
+        **ConcurrentQueue** |    **50** |    **50** |                **1** |     **1.7504 us** | **0.0806 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    50 |                1 |     2.2882 us | 0.0541 us |   1.31 |      0.07 |
+     BlockingCollection |    50 |    50 |                1 |     6.5085 us | 0.0938 us |   3.73 |      0.18 |
+      SynchronizedQueue |    50 |    50 |                1 |     2.1800 us | 0.0139 us |   1.25 |      0.06 |
+        **ConcurrentQueue** |    **50** |   **100** |               **-1** |     **4.6862 us** | **0.0208 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |   100 |               -1 |     5.7488 us | 0.0804 us |   1.23 |      0.02 |
+     BlockingCollection |    50 |   100 |               -1 |    22.8035 us | 3.0473 us |   5.01 |      0.64 |
+      SynchronizedQueue |    50 |   100 |               -1 |     7.5296 us | 0.0931 us |   1.61 |      0.02 |
+        **ConcurrentQueue** |    **50** |   **100** |                **1** |     **1.6933 us** | **0.0110 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |   100 |                1 |     2.2958 us | 0.0697 us |   1.36 |      0.04 |
+     BlockingCollection |    50 |   100 |                1 |     6.4820 us | 0.0494 us |   3.82 |      0.04 |
+      SynchronizedQueue |    50 |   100 |                1 |     2.1791 us | 0.0099 us |   1.29 |      0.01 |
+        **ConcurrentQueue** |   **100** |    **-1** |               **-1** |     **6.6384 us** | **0.0787 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    -1 |               -1 |     6.9712 us | 0.0814 us |   1.05 |      0.02 |
+     BlockingCollection |   100 |    -1 |               -1 |    35.1049 us | 4.4887 us |   5.44 |      0.67 |
+      SynchronizedQueue |   100 |    -1 |               -1 |    15.7968 us | 0.6234 us |   2.39 |      0.10 |
+        **ConcurrentQueue** |   **100** |    **-1** |                **1** |     **2.7321 us** | **0.0932 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    -1 |                1 |     3.0368 us | 0.0262 us |   1.12 |      0.04 |
+     BlockingCollection |   100 |    -1 |                1 |     7.4407 us | 0.0607 us |   2.74 |      0.09 |
+      SynchronizedQueue |   100 |    -1 |                1 |     3.5805 us | 0.0960 us |   1.32 |      0.06 |
+        **ConcurrentQueue** |   **100** |    **50** |               **-1** |     **6.7204 us** | **0.1360 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    50 |               -1 |     7.8006 us | 0.0774 us |   1.16 |      0.03 |
+     BlockingCollection |   100 |    50 |               -1 |   359.9633 us | 1.8706 us |  53.51 |      1.09 |
+      SynchronizedQueue |   100 |    50 |               -1 |    12.7241 us | 0.2875 us |   1.90 |      0.06 |
+        **ConcurrentQueue** |   **100** |    **50** |                **1** |     **2.6575 us** | **0.0158 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    50 |                1 |     3.1897 us | 0.0207 us |   1.20 |      0.01 |
+     BlockingCollection |   100 |    50 |                1 | 1,391.3352 us | 8.2379 us | 522.99 |      4.27 |
+      SynchronizedQueue |   100 |    50 |                1 |     3.2691 us | 0.1015 us |   1.23 |      0.04 |
+        **ConcurrentQueue** |   **100** |   **100** |               **-1** |     **6.5719 us** | **0.0547 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |   100 |               -1 |     8.5435 us | 0.1015 us |   1.30 |      0.02 |
+     BlockingCollection |   100 |   100 |               -1 |    48.7996 us | 9.4255 us |   7.67 |      1.42 |
+      SynchronizedQueue |   100 |   100 |               -1 |    15.7037 us | 0.8678 us |   2.40 |      0.13 |
+        **ConcurrentQueue** |   **100** |   **100** |                **1** |     **2.6204 us** | **0.0091 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |   100 |                1 |     3.7370 us | 0.0743 us |   1.43 |      0.03 |
+     BlockingCollection |   100 |   100 |                1 |    11.8234 us | 0.0873 us |   4.52 |      0.04 |
+      SynchronizedQueue |   100 |   100 |                1 |     3.4981 us | 0.0177 us |   1.34 |      0.01 |

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/netcoreapp1.0/BoundedQueue_Enqueue_Dequeue_Benchmark-report-github.md
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/netcoreapp1.0/BoundedQueue_Enqueue_Dequeue_Benchmark-report-github.md
@@ -1,0 +1,40 @@
+```ini
+
+Host Process Environment Information:
+BenchmarkDotNet.Core=v0.9.9.0
+OS=Windows
+Processor=?, ProcessorCount=8
+Frequency=3507522 ticks, Resolution=285.1016 ns, Timer=TSC
+CLR=CORE, Arch=64-bit ? [RyuJIT]
+GC=Concurrent Workstation
+dotnet cli version: 1.0.0-preview2-003131
+
+Type=BoundedQueue_Enqueue_Dequeue_Benchmark  Mode=Throughput  
+
+```
+                 Method | Items | Limit |      Median |    StdDev | Scaled | Scaled-SD |
+----------------------- |------ |------ |------------ |---------- |------- |---------- |
+        **ConcurrentQueue** |    **50** |    **-1** |   **7.0749 us** | **0.0914 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    -1 |   7.4228 us | 0.0827 us |   1.05 |      0.02 |
+     BlockingCollection |    50 |    -1 |  36.9636 us | 2.4036 us |   5.34 |      0.34 |
+      SynchronizedQueue |    50 |    -1 |  15.3732 us | 0.5077 us |   2.18 |      0.08 |
+        **ConcurrentQueue** |    **50** |    **50** |   **7.0484 us** | **0.0917 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |    50 |   8.4134 us | 0.1526 us |   1.20 |      0.03 |
+     BlockingCollection |    50 |    50 |  50.2187 us | 9.5376 us |   7.48 |      1.34 |
+      SynchronizedQueue |    50 |    50 |  15.0374 us | 0.3315 us |   2.13 |      0.05 |
+        **ConcurrentQueue** |    **50** |   **100** |   **7.0603 us** | **0.1021 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |    50 |   100 |   8.3543 us | 0.0798 us |   1.18 |      0.02 |
+     BlockingCollection |    50 |   100 |  51.4431 us | 5.1939 us |   7.34 |      0.73 |
+      SynchronizedQueue |    50 |   100 |  15.2502 us | 0.6226 us |   2.17 |      0.09 |
+        **ConcurrentQueue** |   **100** |    **-1** |   **9.9110 us** | **0.1666 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    -1 |  10.1370 us | 0.1678 us |   1.03 |      0.02 |
+     BlockingCollection |   100 |    -1 |  58.9588 us | 3.7403 us |   6.01 |      0.38 |
+      SynchronizedQueue |   100 |    -1 |  29.6655 us | 2.0825 us |   3.03 |      0.21 |
+        **ConcurrentQueue** |   **100** |    **50** |   **9.9629 us** | **0.1519 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |    50 |  12.6271 us | 0.3635 us |   1.28 |      0.04 |
+     BlockingCollection |   100 |    50 | 172.5832 us | 3.3398 us |  17.46 |      0.42 |
+      SynchronizedQueue |   100 |    50 |  28.2467 us | 4.9548 us |   2.99 |      0.50 |
+        **ConcurrentQueue** |   **100** |   **100** |  **10.0306 us** | **0.1885 us** |   **1.00** |      **0.00** |
+ BoundedConcurrentQueue |   100 |   100 |  12.4031 us | 0.2527 us |   1.24 |      0.03 |
+     BlockingCollection |   100 |   100 |  70.7232 us | 2.5452 us |   7.03 |      0.28 |
+      SynchronizedQueue |   100 |   100 |  29.4855 us | 3.1710 us |   3.02 |      0.32 |

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/BoundedConcurrentQueueTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/BoundedConcurrentQueueTests.cs
@@ -1,0 +1,29 @@
+﻿using Serilog.Sinks.PeriodicBatching;
+using System;
+using Xunit;
+
+namespace Serilog.Tests.Sinks.PeriodicBatching
+{
+    public class BoundedConcurrentQueueTests
+    {
+        [Fact]
+        public void WhenBoundedShouldNotExceedLimit()
+        {
+            var limit = 100;
+            var queue = new BoundedConcurrentQueue<int>(limit);
+
+            for (int i = 0; i < limit * 2; i++)
+            {
+                queue.TryEnqueue(i);
+            }
+
+            Assert.Equal(limit, queue.Count);
+        }
+
+        [Fact]
+        public void WhenInvalidLimitWillThrow()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BoundedConcurrentQueue<int>(-42));
+        }
+    }
+}


### PR DESCRIPTION
opt-in via new constructor, policy - discard. 
fixes [#6](https://github.com/serilog/serilog-sinks-periodicbatching/issues/6)

micro-bench results (`Limit = -1` means unbounded)
-------net452------------
[BoundedQueue_Enqueue_Benchmark-report.md](https://github.com/skomis-mm/serilog-sinks-periodicbatching/blob/concurrentqueue/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/net452/BoundedQueue_Enqueue_Benchmark-report-github.md)
[BoundedQueue_Enqueue_Dequeue_Benchmark-report.md](https://github.com/skomis-mm/serilog-sinks-periodicbatching/blob/concurrentqueue/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/net452/BoundedQueue_Enqueue_Dequeue_Benchmark-report-github.md)
-------netcoreapp1.0-----
[BoundedQueue_Enqueue_Benchmark-report.md](https://github.com/skomis-mm/serilog-sinks-periodicbatching/blob/concurrentqueue/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/netcoreapp1.0/BoundedQueue_Enqueue_Benchmark-report-github.md)
[BoundedQueue_Enqueue_Dequeue_Benchmark-report.md](https://github.com/skomis-mm/serilog-sinks-periodicbatching/blob/concurrentqueue/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/results/netcoreapp1.0/BoundedQueue_Enqueue_Dequeue_Benchmark-report-github.md)
