### PR TITLE
Extend retry window to the 'advertised' 10 minutes

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BatchedConnectionStatus.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BatchedConnectionStatus.cs
@@ -37,8 +37,8 @@ namespace Serilog.Sinks.PeriodicBatching
         static readonly TimeSpan MinimumBackoffPeriod = TimeSpan.FromSeconds(5);
         static readonly TimeSpan MaximumBackoffInterval = TimeSpan.FromMinutes(10);
 
-        const int FailuresBeforeDroppingBatch = 4;
-        const int FailuresBeforeDroppingQueue = 6;
+        const int FailuresBeforeDroppingBatch = 8;
+        const int FailuresBeforeDroppingQueue = 10;
 
         readonly TimeSpan _period;
 

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/BatchedConnectionStatusTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Sinks/PeriodicBatching/BatchedConnectionStatusTests.cs
@@ -55,24 +55,28 @@ namespace Serilog.Tests.Sinks.PeriodicBatching
         }
 
         [Fact]
-        public void WhenFourFailuresHaveOccurredTheIntervalBacksOffAndBatchIsDropped()
+        public void When8FailuresHaveOccurredTheIntervalBacksOffAndBatchIsDropped()
         {
             var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            bcs.MarkFailure();
-            bcs.MarkFailure();
-            bcs.MarkFailure();
-            bcs.MarkFailure();
-            Assert.Equal(TimeSpan.FromSeconds(40), bcs.NextInterval);
+            for (var i = 0; i < 8; ++i)
+            {
+                Assert.False(bcs.ShouldDropBatch);
+                bcs.MarkFailure();
+            }
+            Assert.Equal(TimeSpan.FromMinutes(10), bcs.NextInterval);
             Assert.True(bcs.ShouldDropBatch);
             Assert.False(bcs.ShouldDropQueue);
         }
 
         [Fact]
-        public void WhenSixFailuresHaveOccurredTheQueueIsDropped()
+        public void When10FailuresHaveOccurredTheQueueIsDropped()
         {
             var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            for (var i = 0; i < 6; ++i )
+            for (var i = 0; i < 10; ++i)
+            {
+                Assert.False(bcs.ShouldDropQueue);
                 bcs.MarkFailure();
+            }
             Assert.True(bcs.ShouldDropQueue);
         }
 


### PR DESCRIPTION
The intention in `BatchedConnectionSchedule` was to retry for 10 minutes, under default settings, before dropping the current batch of buffered log events.

An incorrect retry count meant this was 32 seconds, instead.

This PR bumps the retry window to 00:10:32, and drops the whole queue only after 00:30:32.