### PR TITLE
Simplify the constructors for PeriodicBatchingSink and BoundedConcurrentQueue.

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
+++ b/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>The periodic batching sink for Serilog</Description>
@@ -7,6 +7,7 @@
     <TargetFrameworks>net45;netstandard1.1;netstandard1.2;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.PeriodicBatching</AssemblyName>
+    <RootNamespace>Serilog</RootNamespace>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 
@@ -18,7 +18,7 @@ namespace Serilog.Sinks.PeriodicBatching
             if (queueLimit.HasValue && queueLimit <= 0)
                 throw new ArgumentOutOfRangeException(nameof(queueLimit), "Queue limit must be positive, or `null` to indicate unbounded.");
 
-            _queueLimit = queueLimit ?? NON_BOUNDED;
+            _queueLimit = queueLimit ?? NonBounded;
         }
 
         public int Count => _queue.Count;

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace Serilog.Sinks.PeriodicBatching
 {
-    class BoundedConcurrentQueue<T> 
+    class BoundedConcurrentQueue<T>
     {
         const int NON_BOUNDED = -1;
 
@@ -13,17 +13,12 @@ namespace Serilog.Sinks.PeriodicBatching
 
         int _counter;
 
-        public BoundedConcurrentQueue() 
+        public BoundedConcurrentQueue(int? queueLimit = null)
         {
-            _queueLimit = NON_BOUNDED;
-        }
-
-        public BoundedConcurrentQueue(int queueLimit)
-        {
-            if (queueLimit <= 0)
+            if (queueLimit.HasValue && queueLimit <= 0)
                 throw new ArgumentOutOfRangeException(nameof(queueLimit), "queue limit must be positive");
 
-            _queueLimit = queueLimit;
+            _queueLimit = queueLimit ?? NON_BOUNDED;
         }
 
         public int Count => _queue.Count;

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -53,13 +53,34 @@ namespace Serilog.Sinks.PeriodicBatching
         /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="queueLimit">Maximum number of events in the queue.</param>
-        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int? queueLimit = null)
+        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int? queueLimit)
         {
             _batchSizeLimit = batchSizeLimit;
             _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);
             _status = new BatchedConnectionStatus(period);
-            
+
             _timer = new PortableTimer(cancel => OnTick());
+        }
+
+        /// <summary>
+        /// Construct a sink posting to the specified database.
+        /// </summary>
+        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period) 
+            : this(batchSizeLimit, period, null)
+        {
+        }
+
+        /// <summary>
+        /// Construct a sink posting to the specified database.
+        /// </summary>
+        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="queueLimit">Maximum number of events in the queue.</param>
+        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int queueLimit)
+            : this(batchSizeLimit, period, (int?)queueLimit)
+        {
         }
 
         void CloseAndFlush()

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -52,22 +52,7 @@ namespace Serilog.Sinks.PeriodicBatching
         /// </summary>
         /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="queueLimit">Maximum number of events in the queue.</param>
-        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int? queueLimit)
-        {
-            _batchSizeLimit = batchSizeLimit;
-            _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);
-            _status = new BatchedConnectionStatus(period);
-
-            _timer = new PortableTimer(cancel => OnTick());
-        }
-
-        /// <summary>
-        /// Construct a sink posting to the specified database.
-        /// </summary>
-        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period) 
+        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period)
             : this(batchSizeLimit, period, null)
         {
         }
@@ -81,6 +66,21 @@ namespace Serilog.Sinks.PeriodicBatching
         protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int queueLimit)
             : this(batchSizeLimit, period, (int?)queueLimit)
         {
+        }
+
+        /// <summary>
+        /// Construct a sink posting to the specified database.
+        /// </summary>
+        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="queueLimit">Maximum number of events in the queue.</param>
+        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int? queueLimit)
+        {
+            _batchSizeLimit = batchSizeLimit;
+            _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);
+            _status = new BatchedConnectionStatus(period);
+
+            _timer = new PortableTimer(cancel => OnTick());
         }
 
         void CloseAndFlush()

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -52,25 +52,14 @@ namespace Serilog.Sinks.PeriodicBatching
         /// </summary>
         /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
-        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period)
+        /// <param name="queueLimit">Maximum number of events in the queue.</param>
+        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int? queueLimit = null)
         {
             _batchSizeLimit = batchSizeLimit;
-            _queue = new BoundedConcurrentQueue<LogEvent>();
+            _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);
             _status = new BatchedConnectionStatus(period);
             
             _timer = new PortableTimer(cancel => OnTick());
-        }
-
-        /// <summary>
-        /// Construct a sink posting to the specified database.
-        /// </summary>
-        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="queueLimit">Maximum number of events in the queue.</param>
-        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int queueLimit)
-            : this(batchSizeLimit, period)
-        {
-            _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);
         }
 
         void CloseAndFlush()


### PR DESCRIPTION
The current way that the constructors are implemented prevents some types of configuration and sub-classes of `PeriodicBatchingSink` have two paths of constructor logic. This PR aims to simplify and improve this.

The motivation was needing to extend PeriodicBatchingSink and pass in all configuration as follows:

```c#
public EventHubSink(EventHubClient client, EventHubLogSinkConfiguration config)
    : base(config.BatchSizeLimit, config.BatchPeriod, config.BatchQueueLimit)
{
   _client = client;
}
```

Additionally I've added a RootNamespace declaration to fix warnings about incorrect namespaces.