### PR TITLE
Remove unnecessary dependencies from netstandard2.0 build

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
+++ b/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>The periodic batching sink for Serilog</Description>
@@ -41,8 +41,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
-    <PackageReference Include="System.Threading.Timer" Version="4.0.1" />
   </ItemGroup>
     
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
+++ b/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
   </ItemGroup>
     
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Leaves the empty `<ItemGroup>` to make it nice and easy to scan the CSPROJ :-)