### PR TITLE
Allow NON_BOUNDED value to be used as constructor parameter

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -6,7 +6,7 @@ namespace Serilog.Sinks.PeriodicBatching
 {
     class BoundedConcurrentQueue<T> 
     {
-        public const int NON_BOUNDED = -1;
+        public const int NonBounded = -1;
 
         readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         readonly int _queueLimit;
@@ -14,12 +14,12 @@ namespace Serilog.Sinks.PeriodicBatching
         int _counter;
 
         public BoundedConcurrentQueue() 
-            : this(NON_BOUNDED) { }
+            : this(NonBounded) { }
 
         public BoundedConcurrentQueue(int queueLimit)
         {
-            if (queueLimit <= 0 && queueLimit != NON_BOUNDED)
-                throw new ArgumentOutOfRangeException(nameof(queueLimit), $"Queue limit must be positive, or {NON_BOUNDED} (to indicate unlimited).");
+            if (queueLimit <= 0 && queueLimit != NonBounded)
+                throw new ArgumentOutOfRangeException(nameof(queueLimit), $"Queue limit must be positive, or {NonBounded} (to indicate unlimited).");
 
             _queueLimit = queueLimit;
         }
@@ -28,7 +28,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
         public bool TryDequeue(out T item)
         {
-            if (_queueLimit == NON_BOUNDED)
+            if (_queueLimit == NonBounded)
                 return _queue.TryDequeue(out item);
 
             var result = false;
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
         public bool TryEnqueue(T item)
         {
-            if (_queueLimit == NON_BOUNDED)
+            if (_queueLimit == NonBounded)
             {
                 _queue.Enqueue(item);
                 return true;

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -14,14 +14,12 @@ namespace Serilog.Sinks.PeriodicBatching
         int _counter;
 
         public BoundedConcurrentQueue() 
-        {
-            _queueLimit = NON_BOUNDED;
-        }
+            : this(NON_BOUNDED) { }
 
         public BoundedConcurrentQueue(int queueLimit)
         {
-            if (queueLimit <= 0)
-                throw new ArgumentOutOfRangeException(nameof(queueLimit), "queue limit must be positive");
+            if (queueLimit <= 0 && queueLimit != NON_BOUNDED)
+                throw new ArgumentOutOfRangeException(nameof(queueLimit), $"Queue limit must be positive, or {NON_BOUNDED} (to indicate unlimited).");
 
             _queueLimit = queueLimit;
         }

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -6,7 +6,7 @@ namespace Serilog.Sinks.PeriodicBatching
 {
     class BoundedConcurrentQueue<T> 
     {
-        const int NON_BOUNDED = -1;
+        public const int NON_BOUNDED = -1;
 
         readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         readonly int _queueLimit;

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -38,7 +38,7 @@ namespace Serilog.Sinks.PeriodicBatching
         /// <summary>
         /// Constant used to indicate that the internal queue shouldn't be limited.
         /// </summary>
-        public const int NoQueueLimit = BoundedConcurrentQueue<LogEvent>.NON_BOUNDED;
+        public const int NoQueueLimit = BoundedConcurrentQueue<LogEvent>.NonBounded;
 
         readonly int _batchSizeLimit;
         readonly BoundedConcurrentQueue<LogEvent> _queue;

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -68,10 +68,10 @@ namespace Serilog.Sinks.PeriodicBatching
         /// <param name="queueLimit">Maximum number of events in the queue - use <see cref="NoQueueLimit"/> for an unbounded queue.</param>
         protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int queueLimit)
         {
-            if (!(batchSizeLimit > 0))
-                throw new ArgumentOutOfRangeException(nameof(batchSizeLimit), "Parameter must be greater than 0.");
-            if (!(period > TimeSpan.Zero))
-                throw new ArgumentOutOfRangeException(nameof(period), "Parameter must be greater than the 0 time span.");
+            if (batchSizeLimit <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batchSizeLimit), "The batch size limit must be greater than zero.");
+            if (period <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(period), "The period must be greater than zero.");
 
             _batchSizeLimit = batchSizeLimit;
             _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -68,6 +68,11 @@ namespace Serilog.Sinks.PeriodicBatching
         /// <param name="queueLimit">Maximum number of events in the queue - use <see cref="NoQueueLimit"/> for an unbounded queue.</param>
         protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int queueLimit)
         {
+            if (!(batchSizeLimit > 0))
+                throw new ArgumentOutOfRangeException(nameof(batchSizeLimit), "Parameter must be greater than 0.");
+            if (!(period > TimeSpan.Zero))
+                throw new ArgumentOutOfRangeException(nameof(period), "Parameter must be greater than the 0 time span.");
+
             _batchSizeLimit = batchSizeLimit;
             _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);
             _status = new BatchedConnectionStatus(period);


### PR DESCRIPTION
I'd like to suggest this minor change to allow creating an unlimited queue, without having to use another constructor. This makes it easier to inherit PeriodicBatchingSink as fewer constructor overloads are necessary.