### PR TITLE
Accept the NoQueueLimit constant in legacy constructors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,6 @@
 version: '{build}'
 skip_tags: true
 image: Visual Studio 2019
-install:
-  - ps: mkdir -Force ".\build\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
-  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.1'
-  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 build_script:
 - ps: ./Build.ps1
 test: off

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -20,7 +20,7 @@ namespace Serilog.Sinks.PeriodicBatching
 {
     class BoundedConcurrentQueue<T>
     {
-        public const int Unbounded = -1;
+        const int Unbounded = -1;
 
         readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         readonly int _queueLimit;

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -37,9 +37,10 @@ namespace Serilog.Sinks.PeriodicBatching
     public class PeriodicBatchingSink : ILogEventSink, IDisposable, IBatchedLogEventSink
     {
         /// <summary>
-        /// Constant used to indicate that the internal queue shouldn't be limited.
+        /// Constant used with legacy constructor to indicate that the internal queue shouldn't be limited.
         /// </summary>
-        public const int NoQueueLimit = BoundedConcurrentQueue<LogEvent>.Unbounded;
+        [Obsolete("Implement `IBatchedLogEventSink` and use the `PeriodicBatchingSinkOptions` constructor.")]
+        public const int NoQueueLimit = -1;
 
         readonly IBatchedLogEventSink _batchedLogEventSink;
         readonly int _batchSizeLimit;
@@ -76,6 +77,7 @@ namespace Serilog.Sinks.PeriodicBatching
         /// </summary>
         /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
+        [Obsolete("Implement `IBatchedLogEventSink` and use the `PeriodicBatchingSinkOptions` constructor.")]
         protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period)
             : this(new PeriodicBatchingSinkOptions
             {
@@ -97,13 +99,14 @@ namespace Serilog.Sinks.PeriodicBatching
         /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="queueLimit">Maximum number of events in the queue - use <see cref="NoQueueLimit"/> for an unbounded queue.</param>
+        [Obsolete("Implement `IBatchedLogEventSink` and use the `PeriodicBatchingSinkOptions` constructor.")]
         protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int queueLimit)
             : this(new PeriodicBatchingSinkOptions
             {
                 BatchSizeLimit = batchSizeLimit,
                 Period = period,
                 EagerlyEmitFirstEvent = true,
-                QueueLimit = queueLimit
+                QueueLimit = queueLimit == NoQueueLimit ? (int?)null : queueLimit
             })
         {
             _batchedLogEventSink = this;
@@ -199,6 +202,7 @@ namespace Serilog.Sinks.PeriodicBatching
         protected virtual async Task EmitBatchAsync(IEnumerable<LogEvent> events)
 #pragma warning restore 1998
         {
+            // ReSharper disable once MethodHasAsyncOverload
             EmitBatch(events);
         }
 
@@ -337,6 +341,7 @@ namespace Serilog.Sinks.PeriodicBatching
         protected virtual async Task OnEmptyBatchAsync()
 #pragma warning restore 1998
         {
+            // ReSharper disable once MethodHasAsyncOverload
             OnEmptyBatch();
         }
         

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
@@ -60,6 +60,16 @@ namespace Serilog.Sinks.PeriodicBatching.Tests
         }
     }
 
+    class NullBatchedSink : PeriodicBatchingSink
+    {
+        public NullBatchedSink(int batchSizeLimit, TimeSpan period, int queueLimit)
+#pragma warning disable 618
+            : base(batchSizeLimit, period, queueLimit)
+#pragma warning restore 618
+        {
+        }
+    }
+
     public class PeriodicBatchingSinkTests
     {
         static readonly TimeSpan TinyWait = TimeSpan.FromMilliseconds(200);
@@ -111,6 +121,14 @@ namespace Serilog.Sinks.PeriodicBatching.Tests
             Assert.Equal(1, bs.Batches.Count);
             Assert.True(bs.IsDisposed);
             Assert.False(bs.WasCalledAfterDisposal);
+        }
+
+        [Fact]
+        public void SubclassesCanBeConstructedUsingNoQueueLimitConstant()
+        {
+#pragma warning disable 618
+            var _ = new NullBatchedSink(batchSizeLimit: 100, TimeSpan.FromSeconds(2), queueLimit: PeriodicBatchingSink.NoQueueLimit);
+#pragma warning restore 618
         }
     }
 }


### PR DESCRIPTION
Mark those constructors and the constant obsolete. Fixes #45.