### PR TITLE
Restore obsolete inheritance-based API

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
+++ b/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Buffer batches of log events to be flushed asynchronously.</Description>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.1;netstandard1.2;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Serilog.Sinks.PeriodicBatching.PerformanceTests.csproj
+++ b/test/Serilog.Sinks.PeriodicBatching.PerformanceTests/Serilog.Sinks.PeriodicBatching.PerformanceTests.csproj
@@ -5,6 +5,7 @@
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/BackwardsCompatibilityTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/BackwardsCompatibilityTests.cs
@@ -1,0 +1,21 @@
+#if FEATURE_ASYNCDISPOSABLE
+
+using System.Threading.Tasks;
+using Serilog.Sinks.PeriodicBatching.Tests.Support;
+using Xunit;
+
+namespace Serilog.Sinks.PeriodicBatching.Tests;
+
+public class BackwardsCompatibilityTests
+{
+    [Fact]
+    public async Task LegacySinksAreDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sink = new LegacyDisposeTrackingSink();
+        var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        await logger.DisposeAsync();
+        Assert.True(sink.IsDisposed);
+    }
+}
+
+#endif

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Serilog.Sinks.PeriodicBatching.Tests.csproj
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Serilog.Sinks.PeriodicBatching.Tests.csproj
@@ -5,6 +5,7 @@
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
@@ -19,6 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Support/LegacyDisposeTrackingSink.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Support/LegacyDisposeTrackingSink.cs
@@ -1,0 +1,21 @@
+using System;
+
+#pragma warning disable CS0618
+
+namespace Serilog.Sinks.PeriodicBatching.Tests.Support
+{
+    public class LegacyDisposeTrackingSink : PeriodicBatchingSink
+    {
+        public bool IsDisposed { get; private set; }
+
+        public LegacyDisposeTrackingSink()
+            : base(10, TimeSpan.FromMinutes(1))
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+        }
+    }
+}


### PR DESCRIPTION
3.0.0 removed the inheritance-based API; I think this was too hasty - although the corresponding functions/constructors were marked obsolete two years ago, that change didn't make it into a public release until around eight months ago, which hasn't allowed for enough actively-used but slow-moving sinks to migrate.

This change also ensures the wrapped sink is disposed whether the wrapper started or not; the original behavior (not disposing if `!_started`) is undesirable/unexpected, as far as I can see.