### PR TITLE
Add queue monitoring

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -130,10 +130,12 @@ public class PeriodicBatchingSink : ILogEventSink, IDisposable, IBatchedLogEvent
             throw new ArgumentOutOfRangeException(nameof(options), "The period must be greater than zero.");
         if (options.MonitoringPeriod.HasValue && options.MonitoringPeriod.Value < options.Period)
             throw new ArgumentOutOfRangeException(nameof(options), "The monitoring period should be greater or equal to the batch period.");
+        if (options.MonitoringPeriod.HasValue && options.MonitoringPeriod.Value == Timeout.InfiniteTimeSpan)
+            throw new ArgumentOutOfRangeException(nameof(options), "The monitoring period should not be infinite.");
         if (options.MonitoringPeriod.HasValue && options.MonitoringCallbackAsync is null)
-            throw new ArgumentOutOfRangeException(nameof(options), "The monitoring callback should not be null when the monitoring period has a value.");
+            throw new ArgumentNullException(nameof(options), "The monitoring callback should not be null when the monitoring period has a value.");
         if (!options.MonitoringPeriod.HasValue && options.MonitoringCallbackAsync is not null)
-            throw new ArgumentOutOfRangeException(nameof(options), "The monitoring period should not be null when the monitoring callback is defined.");
+            throw new ArgumentNullException(nameof(options), "The monitoring period should not be null when the monitoring callback is defined.");
 
         _batchSizeLimit = options.BatchSizeLimit;
         _queue = new(options.QueueLimit);

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSinkOptions.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSinkOptions.cs
@@ -41,4 +41,16 @@ public class PeriodicBatchingSinkOptions
     /// for an unbounded queue. The default is <c>100000</c>.
     /// </summary>
     public int? QueueLimit { get; set; } = 100000;
+
+    /// <summary>
+    /// The time to wait between two <see cref="MonitoringCallbackAsync"/> trigger.
+    /// The default is <c>null</c>.
+    /// </summary>
+    public TimeSpan? MonitoringPeriod { get; set; } = null;
+
+    /// <summary>
+    /// Callback called every <see cref="MonitoringPeriod"/> with the number of events hold in the queue as parameter.
+    /// The default is <c>null</c>.
+    /// </summary>
+    public Func<int, Task>? MonitoringCallbackAsync { get; set; } = null;
 }

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimer.cs
@@ -42,7 +42,7 @@ class PortableTimer : IDisposable
 #endif
     }
 
-    public void Start(TimeSpan interval)
+    public virtual void Start(TimeSpan interval)
     {
         if (interval < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(interval));
 
@@ -64,7 +64,7 @@ class PortableTimer : IDisposable
         }
     }
 
-    async void OnTick()
+    protected async void OnTick()
     {
         try
         {

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimerFactory.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PortableTimerFactory.cs
@@ -1,0 +1,11 @@
+﻿namespace Serilog.Sinks.PeriodicBatching;
+
+/// <summary>
+/// Utils class that allow replacement of real timers in the context of unit tests
+/// </summary>
+internal class PortableTimerFactory
+{
+    public virtual PortableTimer CreateMainTimer(Func<CancellationToken, Task> onTick) => new PortableTimer(onTick);
+
+    public virtual PortableTimer CreateMonitoringTimer(Func<CancellationToken, Task> onTick) => new PortableTimer(onTick);
+}

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
@@ -1,6 +1,7 @@
 ﻿using Serilog.Sinks.PeriodicBatching.Tests.Support;
 using Xunit;
 using Serilog.Tests.Support;
+using System.Threading;
 
 namespace Serilog.Sinks.PeriodicBatching.Tests;
 
@@ -78,5 +79,64 @@ public class PeriodicBatchingSinkTests
         Assert.Equal(1, bs.Batches.Count);
         Assert.True(bs.IsDisposed);
         Assert.False(bs.WasCalledAfterDisposal);
+    }
+
+    [Fact]
+    public void WhenTheQueueIsFilledQuickerThanItTakesToEmptyItShouldBeVisibleThroughTheMonitoringCallback()
+    {
+        var bs = new InMemoryBatchedSink(TinyWait); // Will really take TinyWait to process a batch
+        var monitoring = new Monitoring();
+        var batchSizeLimit = 2;
+        var opts = new PeriodicBatchingSinkOptions
+        {
+            BatchSizeLimit = batchSizeLimit,
+            EagerlyEmitFirstEvent = false,
+            Period = MicroWait, // Not used here as we trigger the tick manually
+            MonitoringPeriod = MicroWait, // same
+            MonitoringCallbackAsync = monitoring.MonitoringCallback,
+        };
+        var fakeTimers = new ManuallyTriggeredTimerFactory();
+        var pbs = new PeriodicBatchingSink(bs, opts, fakeTimers);
+
+        // Start filling the queue
+        FillQueueWithOneBatch(pbs, batchSizeLimit);
+        fakeTimers.CollectQueueState();
+        Assert.Equal(2, monitoring.NumberOfEventsInTheQueue);
+
+        // Start emptying the queue, but it will take one TinyWait per batch
+        fakeTimers.StartProcessingLogEvents();
+        fakeTimers.CollectQueueState();
+        Assert.Equal(0, monitoring.NumberOfEventsInTheQueue);
+
+        // Filling the queue again, but quicker than the TinyWait => monitoring should show that it grows
+        FillQueueWithOneBatch(pbs, batchSizeLimit);
+        fakeTimers.CollectQueueState();
+        Assert.Equal(2, monitoring.NumberOfEventsInTheQueue);
+        FillQueueWithOneBatch(pbs, batchSizeLimit);
+        fakeTimers.CollectQueueState();
+        Assert.Equal(4, monitoring.NumberOfEventsInTheQueue);
+        FillQueueWithOneBatch(pbs, batchSizeLimit);
+        fakeTimers.CollectQueueState();
+        Assert.Equal(6, monitoring.NumberOfEventsInTheQueue);
+
+        // Now let's wait the 3 TinyWait and observe the queue going down
+        Thread.Sleep(TinyWait);
+        fakeTimers.CollectQueueState();
+        Assert.Equal(4, monitoring.NumberOfEventsInTheQueue);
+        Thread.Sleep(TinyWait);
+        fakeTimers.CollectQueueState();
+        Assert.Equal(2, monitoring.NumberOfEventsInTheQueue);
+        Thread.Sleep(TinyWait);
+        fakeTimers.CollectQueueState();
+        Assert.Equal(0, monitoring.NumberOfEventsInTheQueue);
+    }
+
+    private void FillQueueWithOneBatch(PeriodicBatchingSink pbs, int batchSizeLimit)
+    {
+        var evt = Some.InformationEvent();
+        for (int i = 0; i < batchSizeLimit; i++)
+        {
+            pbs.Emit(evt);
+        }
     }
 }

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
@@ -1,7 +1,6 @@
 ﻿using Serilog.Sinks.PeriodicBatching.Tests.Support;
 using Xunit;
 using Serilog.Tests.Support;
-using System.Threading;
 
 namespace Serilog.Sinks.PeriodicBatching.Tests;
 
@@ -138,5 +137,49 @@ public class PeriodicBatchingSinkTests
         {
             pbs.Emit(evt);
         }
+    }
+
+    [Fact]
+    public void WhenSettingAMonitoringPeriodSmallerThanTheBatchingPeriodWillThrow()
+    {
+        var constructWithWrongParameters = () => new PeriodicBatchingSink(new InMemoryBatchedSink(MicroWait), new PeriodicBatchingSinkOptions
+        {
+            Period = TinyWait,
+            MonitoringPeriod = TinyWait.Subtract(MicroWait),
+        });
+        Assert.Throws<ArgumentOutOfRangeException>(constructWithWrongParameters);
+    }
+
+    [Fact]
+    public void WhenSettingAMonitoringPeriodToInfiniteWillThrow()
+    {
+        var constructWithWrongParameters = () => new PeriodicBatchingSink(new InMemoryBatchedSink(MicroWait), new PeriodicBatchingSinkOptions
+        {
+            Period = TinyWait,
+            MonitoringPeriod = Timeout.InfiniteTimeSpan,
+        });
+        Assert.Throws<ArgumentOutOfRangeException>(constructWithWrongParameters);
+    }
+
+    [Fact]
+    public void WhenSettingAMonitoringPeriodButNoCallbackWillThrow()
+    {
+        var constructWithWrongParameters = () => new PeriodicBatchingSink(new InMemoryBatchedSink(MicroWait), new PeriodicBatchingSinkOptions
+        {
+            Period = TinyWait,
+            MonitoringPeriod = TinyWait,
+        });
+        Assert.Throws<ArgumentNullException>(constructWithWrongParameters);
+    }
+
+    [Fact]
+    public void WhenSettingAMonitoringCallbackButNoPeriodWillThrow()
+    {
+        var constructWithWrongParameters = () => new PeriodicBatchingSink(new InMemoryBatchedSink(MicroWait), new PeriodicBatchingSinkOptions
+        {
+            Period = TinyWait,
+            MonitoringCallbackAsync = _ => Task.FromResult(0),
+        });
+        Assert.Throws<ArgumentNullException>(constructWithWrongParameters);
     }
 }

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Serilog.Sinks.PeriodicBatching.Tests.csproj
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Serilog.Sinks.PeriodicBatching.Tests.csproj
@@ -17,13 +17,27 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <Choose>
+    <When Condition="'$(TargetFramework)' != 'net6.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+        <PackageReference Include="xunit" Version="2.2.0" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'net6.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+      </ItemGroup>
+    </When>
+  </Choose>
+    
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Support/ManuallyTriggeredTimer.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Support/ManuallyTriggeredTimer.cs
@@ -1,0 +1,24 @@
+﻿namespace Serilog.Sinks.PeriodicBatching.Tests.Support;
+
+internal class ManuallyTriggeredTimer : PortableTimer
+{
+    public ManuallyTriggeredTimer(Func<CancellationToken, Task> onTick) : base(onTick)
+    {
+    }
+
+    /// <summary>
+    /// Manually trigger the timer tick
+    /// </summary>
+    public void TriggerTick()
+    {
+        OnTick();
+    }
+
+    /// <summary>
+    /// Remove real timer, use <see cref="TriggerTick"/> to have a better control on the timing in the context of a test
+    /// </summary>
+    /// <param name="interval"></param>
+    public override void Start(TimeSpan interval) 
+    {
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Support/ManuallyTriggeredTimerFactory.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Support/ManuallyTriggeredTimerFactory.cs
@@ -1,0 +1,38 @@
+﻿namespace Serilog.Sinks.PeriodicBatching.Tests.Support;
+
+internal class ManuallyTriggeredTimerFactory : PortableTimerFactory
+{
+    const int SmallWaitToLetTheTaskStartBeforeContinuingTheTest = 10;
+
+    public ManuallyTriggeredTimer? MainTimer { get; set; }
+    public ManuallyTriggeredTimer? MonitoringTimer { get; set; }
+
+    public override PortableTimer CreateMainTimer(Func<CancellationToken, Task> onTick)
+    {
+        MainTimer = new ManuallyTriggeredTimer(onTick);
+        return MainTimer;
+    }
+
+    public override PortableTimer CreateMonitoringTimer(Func<CancellationToken, Task> onTick)
+    {
+        MonitoringTimer = new ManuallyTriggeredTimer(onTick);
+        return MonitoringTimer;
+    }
+
+    public void CollectQueueState()
+    {
+        TriggerTick(MonitoringTimer!);
+    }
+
+    public void StartProcessingLogEvents()
+    {
+        TriggerTick(MainTimer!);
+    }
+
+    private void TriggerTick(ManuallyTriggeredTimer timer)
+    {
+        // The tick needs to run on its own thread so that we can empty the queue, fill it and collect the queue state in parallel
+        Task.Run(() => timer.TriggerTick());
+        Thread.Sleep(SmallWaitToLetTheTaskStartBeforeContinuingTheTest);
+    }
+}

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Support/Monitoring.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Support/Monitoring.cs
@@ -1,0 +1,16 @@
+﻿namespace Serilog.Sinks.PeriodicBatching.Tests.Support;
+
+class Monitoring
+{
+    public int NumberOfEventsInTheQueue { get; private set; }
+
+    public Task MonitoringCallback(int numberOfEventsInTheQueue)
+    {
+        NumberOfEventsInTheQueue = numberOfEventsInTheQueue;
+#if NET452
+        return Task.FromResult(1);
+#else
+        return Task.CompletedTask;
+#endif
+    }
+}


### PR DESCRIPTION
This PR implements issue #61 .

I changed my mind on the way to monitor the queue...

Instead of configuring just a threshold that would trigger one callback when going above and another one when going below as proposed in the issue, i figured it is more interesting to monitor it "real time" with a timer and a callback that takes the number of events in the queue.

The hard part was to have a not flaky unit test (combination of the new monitoring timer with the existing timer was quite hard to synchronize in tests). After a lot of effort to try to make it work, i decided to create a way to mock the timers and have a better control over the timing.

The impact of this refactoring seems reasonable to me as there is no change publicly, just a new internal constructor only visible in tests (so the PortableTimer is still not visible by users of the lib).

Let me know if you agree with the approach !