### PR TITLE
Remove incorrect/outdated class-level doc on `PeriodicBatchingSink`

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -23,12 +23,6 @@ namespace Serilog.Sinks.PeriodicBatching;
 /// <summary>
 /// Buffers log events into batches for background flushing.
 /// </summary>
-/// <remarks>
-/// To avoid unbounded memory growth, events are discarded after attempting
-/// to send a batch, regardless of whether the batch succeeded or not. Implementers
-/// that want to change this behavior need to either implement from scratch, or
-/// embed retry logic in the batch emitting functions.
-/// </remarks>
 public class PeriodicBatchingSink : ILogEventSink, IDisposable, IBatchedLogEventSink
 #if FEATURE_ASYNCDISPOSABLE
         , IAsyncDisposable


### PR DESCRIPTION
Retries have been implemented via `BatchedConnectionStatus` for a LONG time (retry behavior is documented there).