### PR TITLE
Prevent capturing of the sink-creation-time `ExecutionContext` by the batching loop/batched sink

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -75,7 +75,11 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
         _waitForShutdownSignal = Task.Delay(Timeout.InfiniteTimeSpan, _shutdownSignal.Token)
             .ContinueWith(e => e.Exception, TaskContinuationOptions.OnlyOnFaulted);
 
-        _runLoop = Task.Run(LoopAsync);
+        // The conditional here is no longer required in .NET 8+ (dotnet/runtime#82912)
+        using (ExecutionContext.IsFlowSuppressed() ? (IDisposable?)null : ExecutionContext.SuppressFlow())
+        {
+            _runLoop = Task.Run(LoopAsync);
+        }
     }
 
     /// <summary>

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/PeriodicBatchingSinkTests.cs
@@ -86,4 +86,27 @@ public class PeriodicBatchingSinkTests
         Assert.True(bs.IsDisposed);
         Assert.False(bs.WasCalledAfterDisposal);
     }
+
+    [Fact]
+    public void ExecutionContextDoesNotFlowToBatchedSink()
+    {
+        var local = new AsyncLocal<int>
+        {
+            Value = 5
+        };
+
+        var observed = 17;
+        var bs = new CallbackBatchedSink(_ =>
+        {
+            observed = local.Value;
+            return Task.CompletedTask;
+        });
+        
+        var pbs = new PeriodicBatchingSink(bs, new());
+        var evt = Some.InformationEvent();
+        pbs.Emit(evt);
+        pbs.Dispose();
+
+        Assert.Equal(default(int), observed);
+    }
 }

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Support/CallbackBatchedSink.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Support/CallbackBatchedSink.cs
@@ -1,0 +1,16 @@
+using Serilog.Events;
+
+namespace Serilog.Sinks.PeriodicBatching.Tests.Support;
+
+class CallbackBatchedSink(Func<IEnumerable<LogEvent>, Task> callback) : IBatchedLogEventSink
+{
+    public Task EmitBatchAsync(IEnumerable<LogEvent> batch)
+    {
+        return callback(batch);
+    }
+
+    public Task OnEmptyBatchAsync()
+    {
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
This reinstates @CodeBlanch's fix for #52 originally committed in #53.