### PR TITLE
Avoid leaking task/cancellation objects when no events are passing through the sink

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -228,6 +228,9 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
             return false;
         }
 
+        if (waitToRead.Status is not TaskStatus.RanToCompletion)
+            return false;
+        
         return await waitToRead;
     }
     

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -49,6 +49,7 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
     readonly FailureAwareBatchScheduler _batchScheduler;
     readonly Queue<LogEvent> _currentBatch = new();
     readonly Task _waitForShutdownSignal;
+    Task<bool>? _cachedWaitToRead;
 
     /// <summary>
     /// Construct a <see cref="PeriodicBatchingSink"/>.
@@ -205,7 +206,10 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
     // Wait until `reader` has items to read. Returns `false` if the `timeout` task completes, or if the reader is cancelled.
     async Task<bool> TryWaitToReadAsync(ChannelReader<LogEvent> reader, Task timeout, CancellationToken cancellationToken)
     {
-        var completed = await Task.WhenAny(timeout, reader.WaitToReadAsync(cancellationToken).AsTask()).ConfigureAwait(false);
+        var waitToRead = _cachedWaitToRead ?? reader.WaitToReadAsync(cancellationToken).AsTask();
+        _cachedWaitToRead = null;
+        
+        var completed = await Task.WhenAny(timeout, waitToRead).ConfigureAwait(false);
 
         // Avoid unobserved task exceptions in the cancellation and failure cases. Note that we may not end up observing
         // read task cancellation exceptions during shutdown, may be some room to improve.
@@ -213,9 +217,18 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
         {
             WriteToSelfLog($"could not read from queue: {completed.Exception}");
         }
+
+        if (completed == timeout)
+        {
+            // Dropping references to `waitToRead` will cause it and some supporting objects to leak; disposing it
+            // will break the channel and cause future attempts to read to fail. So, we cache and reuse it next time
+            // around the loop.
             
-        // `Task.IsCompletedSuccessfully` not available in .NET Standard 2.0/Framework.
-        return completed != timeout && completed is { IsCompleted: true, IsCanceled: false, IsFaulted: false };
+            _cachedWaitToRead = waitToRead;
+            return false;
+        }
+
+        return await waitToRead;
     }
     
     /// <inheritdoc/>


### PR DESCRIPTION
Fixes #76 