### PR TITLE
4.1.0 Release

### DIFF
--- a/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
+++ b/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Buffer batches of log events to be flushed asynchronously.</Description>
-    <VersionPrefix>4.0.1</VersionPrefix>
+    <VersionPrefix>4.0.2</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net462</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net6.0</TargetFrameworks>

--- a/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
+++ b/src/Serilog.Sinks.PeriodicBatching/Serilog.Sinks.PeriodicBatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Buffer batches of log events to be flushed asynchronously.</Description>
-    <VersionPrefix>4.0.2</VersionPrefix>
+    <VersionPrefix>4.1.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net462</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net6.0</TargetFrameworks>

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -228,6 +228,9 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
             return false;
         }
 
+        if (waitToRead.Status is not TaskStatus.RanToCompletion)
+            return false;
+        
         return await waitToRead;
     }
     

--- a/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -49,6 +49,7 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
     readonly FailureAwareBatchScheduler _batchScheduler;
     readonly Queue<LogEvent> _currentBatch = new();
     readonly Task _waitForShutdownSignal;
+    Task<bool>? _cachedWaitToRead;
 
     /// <summary>
     /// Construct a <see cref="PeriodicBatchingSink"/>.
@@ -205,7 +206,10 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
     // Wait until `reader` has items to read. Returns `false` if the `timeout` task completes, or if the reader is cancelled.
     async Task<bool> TryWaitToReadAsync(ChannelReader<LogEvent> reader, Task timeout, CancellationToken cancellationToken)
     {
-        var completed = await Task.WhenAny(timeout, reader.WaitToReadAsync(cancellationToken).AsTask()).ConfigureAwait(false);
+        var waitToRead = _cachedWaitToRead ?? reader.WaitToReadAsync(cancellationToken).AsTask();
+        _cachedWaitToRead = null;
+        
+        var completed = await Task.WhenAny(timeout, waitToRead).ConfigureAwait(false);
 
         // Avoid unobserved task exceptions in the cancellation and failure cases. Note that we may not end up observing
         // read task cancellation exceptions during shutdown, may be some room to improve.
@@ -213,9 +217,18 @@ public sealed class PeriodicBatchingSink : ILogEventSink, IDisposable
         {
             WriteToSelfLog($"could not read from queue: {completed.Exception}");
         }
+
+        if (completed == timeout)
+        {
+            // Dropping references to `waitToRead` will cause it and some supporting objects to leak; disposing it
+            // will break the channel and cause future attempts to read to fail. So, we cache and reuse it next time
+            // around the loop.
             
-        // `Task.IsCompletedSuccessfully` not available in .NET Standard 2.0/Framework.
-        return completed != timeout && completed is { IsCompleted: true, IsCanceled: false, IsFaulted: false };
+            _cachedWaitToRead = waitToRead;
+            return false;
+        }
+
+        return await waitToRead;
     }
     
     /// <inheritdoc/>

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/BackwardsCompatibilityTests.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/BackwardsCompatibilityTests.cs
@@ -1,0 +1,60 @@
+#if FEATURE_ASYNCDISPOSABLE
+
+using Serilog.Sinks.PeriodicBatching.Tests.Support;
+using Serilog.Tests.Support;
+using Xunit;
+
+namespace Serilog.Sinks.PeriodicBatching.Tests;
+
+public class BackwardsCompatibilityTests
+{
+    static readonly TimeSpan TinyWait = TimeSpan.FromMilliseconds(200);
+    
+    [Fact]
+    public void LegacyWhenAnEventIsEnqueuedItIsWrittenToABatchOnDispose()
+    {
+        var bs = new LegacyDisposeTrackingSink();
+        var evt = Some.InformationEvent();
+        bs.Emit(evt);
+        bs.Dispose();
+        var batch = Assert.Single(bs.Batches);
+        var batched = Assert.Single(batch);
+        Assert.Same(evt, batched);
+        Assert.True(bs.IsDisposed);
+        Assert.False(bs.WasCalledAfterDisposal);
+    }
+    
+    [Fact]
+    public void LegacyWhenAnEventIsEnqueuedItIsWrittenToABatchOnTimer()
+    {
+        var bs = new LegacyDisposeTrackingSink();
+        var evt = Some.InformationEvent();
+        bs.Emit(evt);
+        Thread.Sleep(TinyWait + TinyWait);
+        bs.Stop();
+        bs.Dispose();
+        Assert.Single(bs.Batches);
+        Assert.True(bs.IsDisposed);
+        Assert.False(bs.WasCalledAfterDisposal);
+    }
+    
+    [Fact]
+    public void LegacySinksAreDisposedWhenLoggerIsDisposed()
+    {
+        var sink = new LegacyDisposeTrackingSink();
+        var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        logger.Dispose();
+        Assert.True(sink.IsDisposed);
+    }
+    
+    [Fact]
+    public async Task LegacySinksAreDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sink = new LegacyDisposeTrackingSink();
+        var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        await logger.DisposeAsync();
+        Assert.True(sink.IsDisposed);
+    }
+}
+
+#endif

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Support/InMemoryBatchedSink.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Support/InMemoryBatchedSink.cs
@@ -28,7 +28,7 @@ sealed class InMemoryBatchedSink(TimeSpan batchEmitDelay) : IBatchedLogEventSink
         lock (_stateLock)
         {
             if (_stopped)
-                return Task.FromResult(0);
+                return Task.CompletedTask;
 
             if (IsDisposed)
                 WasCalledAfterDisposal = true;
@@ -37,10 +37,10 @@ sealed class InMemoryBatchedSink(TimeSpan batchEmitDelay) : IBatchedLogEventSink
             Batches.Add(events.ToList());
         }
 
-        return Task.FromResult(0);
+        return Task.CompletedTask;
     }
 
-    public Task OnEmptyBatchAsync() => Task.FromResult(0);
+    public Task OnEmptyBatchAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/test/Serilog.Sinks.PeriodicBatching.Tests/Support/LegacyDisposeTrackingSink.cs
+++ b/test/Serilog.Sinks.PeriodicBatching.Tests/Support/LegacyDisposeTrackingSink.cs
@@ -1,0 +1,49 @@
+using Serilog.Events;
+
+#pragma warning disable CS0618
+
+namespace Serilog.Sinks.PeriodicBatching.Tests.Support;
+
+public class LegacyDisposeTrackingSink()
+    : PeriodicBatchingSink(10, TimeSpan.FromMinutes(1))
+{
+    readonly object _stateLock = new();
+    bool _stopped;
+
+    // Postmortem only
+    public bool WasCalledAfterDisposal { get; private set; }
+    public bool IsDisposed { get; private set; }
+    public IList<IList<LogEvent>> Batches { get; } = new List<IList<LogEvent>>();
+
+    public void Stop()
+    {
+        lock (_stateLock)
+        {
+            _stopped = true;
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        
+        lock (_stateLock)
+        {
+            IsDisposed = true;
+        }
+    }
+
+    protected override void EmitBatch(IEnumerable<LogEvent> events)
+    {
+        lock (_stateLock)
+        {
+            if (_stopped)
+                return;
+
+            if (IsDisposed)
+                WasCalledAfterDisposal = true;
+
+            Batches.Add(events.ToList());
+        }
+    }
+}


### PR DESCRIPTION
 * #77 - avoid leaking memory when no events are passing through the sink (@nblumhardt)
 * #75 - reinstate the legacy inheritance-based API again (@nblumhardt)

The intention of this release, with #75, is that the functionality and API in this sink will be frozen, and future development will move to a built-in batching feature in `serilog/serilog`.